### PR TITLE
fix(module/date): Undefined prop when exporting a non-UTC FastjsDate object to fDate

### DIFF
--- a/src/date/main.ts
+++ b/src/date/main.ts
@@ -83,7 +83,7 @@ class FastjsDate extends FastjsBaseModule<FastjsDate> {
         return {
             t: t,
             z: this.timezoneDiff,
-            u: this.isUTC || toUTC
+            u: toUTC || this.isUTC
         }
     }
 


### PR DESCRIPTION
Fixed #88: Undefined prop when exporting a non-UTC FastjsDate object to fDate