### PR TITLE
feat(core/request): add query parameters to URL

### DIFF
--- a/packages/core/src/request/core.ts
+++ b/packages/core/src/request/core.ts
@@ -1,17 +1,17 @@
-import _dev from "../dev";
-import { addQuery, parse } from "./lib";
-import { globalConfig } from "./config";
-
-import type { FastjsRequest } from "./fetch-types";
 import type {
-  RequestHooks,
-  RequestMethod,
-  RequestReturn,
   CallbackObject,
   FailedParams,
   RequestHook,
-  RequestHookKey
+  RequestHookKey,
+  RequestHooks,
+  RequestMethod,
+  RequestReturn
 } from "./def";
+import { addQuery, parse } from "./lib";
+
+import type { FastjsRequest } from "./fetch-types";
+import _dev from "../dev";
+import { globalConfig } from "./config";
 
 export function sendRequest(
   request: FastjsRequest,
@@ -61,7 +61,13 @@ export function sendRequest(
     if (!runHooks(hooks.before, [request]))
       return hookFailed("before", request, null);
 
-    request.request = new Request(addQuery(url || request.url, data.query), {
+    let pathParamMatches: string[] = [];
+    [url, pathParamMatches] = addQuery(url || request.url, data.query);
+    for (const match of pathParamMatches) {
+      delete request.data[match];
+    }
+
+    request.request = new Request(url, {
       method,
       headers: request.config.headers,
       body: data.body as BodyInit

--- a/packages/core/test/unit/request/request.test.ts
+++ b/packages/core/test/unit/request/request.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
-import { request } from "@/main";
+
 import { addQuery } from "@/request/lib";
+import { request } from "@/main";
 
 test("Get a json response and use", async () => {
   const data = await request.get("https://reqres.in/api/users");
@@ -61,17 +62,17 @@ test("Send a delete request", async () => {
 });
 
 test("Should add query to url", () => {
-  const url = addQuery("https://reqres.in/api/users", {
+  const [url] = addQuery("https://reqres.in/api/users", {
     page: 2
   });
   expect(url).toMatchInlineSnapshot(`"https://reqres.in/api/users?page=2"`);
 
-  const url2 = addQuery("https://reqres.in/api/users/:id", {
+  const [url2] = addQuery("https://reqres.in/api/users/:id", {
     id: 2
   });
   expect(url2).toMatchInlineSnapshot(`"https://reqres.in/api/users/2"`);
 
-  const url3 = addQuery("https://reqres.in/api/users/:id/:name", {
+  const [url3] = addQuery("https://reqres.in/api/users/:id/:name", {
     id: 2,
     name: "XiaoDong"
   });

--- a/packages/core/test/unit/request/request.test.ts
+++ b/packages/core/test/unit/request/request.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 import { request } from "@/main";
-import { addQuery } from '@/request/lib'
+import { addQuery } from "@/request/lib";
 
 test("Get a json response and use", async () => {
   const data = await request.get("https://reqres.in/api/users");
@@ -51,27 +51,31 @@ test("Send a patch request", async () => {
 });
 
 test("Send a delete request", async () => {
-  request.delete("https://reqres.in/api/users/:id", {
-    id: 2
-  }).then((data, req) => {
-    expect(req.status).toBe(204);
-  });
+  request
+    .delete("https://reqres.in/api/users/:id", {
+      id: 2
+    })
+    .then((data, req) => {
+      expect(req.status).toBe(204);
+    });
 });
 
-test('Should add query to url', () => {
-  const url = addQuery('https://reqres.in/api/users', {
+test("Should add query to url", () => {
+  const url = addQuery("https://reqres.in/api/users", {
     page: 2
-  })
-  expect(url).toMatchInlineSnapshot(`"https://reqres.in/api/users?page=2"`)
+  });
+  expect(url).toMatchInlineSnapshot(`"https://reqres.in/api/users?page=2"`);
 
-  const url2 = addQuery('https://reqres.in/api/users/:id',{
+  const url2 = addQuery("https://reqres.in/api/users/:id", {
     id: 2
-  })
-  expect(url2).toMatchInlineSnapshot(`"https://reqres.in/api/users/2"`)
+  });
+  expect(url2).toMatchInlineSnapshot(`"https://reqres.in/api/users/2"`);
 
-  const url3 = addQuery('https://reqres.in/api/users/:id/:name',{
+  const url3 = addQuery("https://reqres.in/api/users/:id/:name", {
     id: 2,
-    name: 'XiaoDong'
-  })
-  expect(url3).toMatchInlineSnapshot(`"https://reqres.in/api/users/2/XiaoDong"`)
-})
+    name: "XiaoDong"
+  });
+  expect(url3).toMatchInlineSnapshot(
+    `"https://reqres.in/api/users/2/XiaoDong"`
+  );
+});

--- a/packages/core/test/unit/request/request.test.ts
+++ b/packages/core/test/unit/request/request.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "vitest";
 import { request } from "@/main";
+import { addQuery } from '@/request/lib'
 
 test("Get a json response and use", async () => {
   const data = await request.get("https://reqres.in/api/users");
@@ -27,7 +28,8 @@ test("Send a post request", async () => {
 
 test("Send a put request", async () => {
   request
-    .put("https://reqres.in/api/users/2", {
+    .put("https://reqres.in/api/users/:id", {
+      id: 2,
       name: "XiaoDong",
       job: "Software Engineer"
     })
@@ -38,7 +40,8 @@ test("Send a put request", async () => {
 
 test("Send a patch request", async () => {
   request
-    .patch("https://reqres.in/api/users/2", {
+    .patch("https://reqres.in/api/users/:id", {
+      id: 2,
       name: "XiaoDong",
       job: "Software Engineer"
     })
@@ -48,7 +51,27 @@ test("Send a patch request", async () => {
 });
 
 test("Send a delete request", async () => {
-  request.delete("https://reqres.in/api/users/2").then((data, req) => {
+  request.delete("https://reqres.in/api/users/:id", {
+    id: 2
+  }).then((data, req) => {
     expect(req.status).toBe(204);
   });
 });
+
+test('Should add query to url', () => {
+  const url = addQuery('https://reqres.in/api/users', {
+    page: 2
+  })
+  expect(url).toMatchInlineSnapshot(`"https://reqres.in/api/users?page=2"`)
+
+  const url2 = addQuery('https://reqres.in/api/users/:id',{
+    id: 2
+  })
+  expect(url2).toMatchInlineSnapshot(`"https://reqres.in/api/users/2"`)
+
+  const url3 = addQuery('https://reqres.in/api/users/:id/:name',{
+    id: 2,
+    name: 'XiaoDong'
+  })
+  expect(url3).toMatchInlineSnapshot(`"https://reqres.in/api/users/2/XiaoDong"`)
+})


### PR DESCRIPTION
Automatically add parameters by parsing the configuration of the URL

```
https://reqres.in/api/users/2
```

```
url:
https://reqres.in/api/users/:id
query:
{
	id: 2
}
```